### PR TITLE
Add BharatViz

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -94,3 +94,9 @@
   description: "Explore 12 years of NASA satellite nighttime light data across 196 countries and 3,193 regions — a proxy for economic activity, urbanisation, and conflict"
   url: "https://aniketshevade.in/nightpulse/"
   tags: ["nighttime-lights", "nasa", "economic-activity", "global", "data-visualisation"]
+
+- name: "BharatViz"
+  category: "Visualisations"
+  description: "Open-source choropleth map generator for India. Upload a CSV and get publication-ready state or district-level maps with customizable color scales."
+  url: "https://bharatviz.org"
+  tags: ["india", "data-visualisation", "maps", "open-source", "public-data"]


### PR DESCRIPTION
Adds [BharatViz](https://bharatviz.org) to the Visualisations category.

BharatViz is an open-source choropleth map generator for India. Users upload a CSV and get publication-ready state or district-level maps with customizable color scales. Supports 27 boundary sets spanning historical censuses (1941-2011), LGD, NFHS, and more.

- Category: Visualisations
- URL: https://bharatviz.org
- Source: https://github.com/saketlab/bharatviz