### PR TITLE
Add CitizenView project to analytical tools

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -124,3 +124,9 @@
   description: "Takshashila research methods in a browser — 14 tools covering policy analysis, stakeholder mapping, causal loops, drafting, and review, in three guided paths. Zero backend; bring your own API key."
   url: "https://takshashilainst.github.io/scholar-web/"
   tags: ["policy-analysis", "research-tools", "india", "ai", "open-source"]
+
+  - name: "CitizenView"
+  category: "Analytical Tools"
+  description: "Makes Indian parliamentary bills accessible to citizens through plain-language summaries in regional languages, with MP contact tools to enable direct civic engagement."
+  url: "https://app.citizenview.in"
+  tags: ["parliament", "india", "civic-tech", "multilingual", "open-data"]


### PR DESCRIPTION
CitizenView is a civic tech platform that makes Indian parliamentary legislation accessible to ordinary citizens. We provide plain-language bill summaries in regional languages, plus an action layer that connects users directly with their MPs. Categorized under Analytical Tools as the closest fit; happy to recategorize if maintainers prefer.