### PR TITLE
Add Judiciary Entity Map (JEM)

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -130,3 +130,9 @@
   description: "Makes Indian parliamentary bills accessible to citizens through plain-language summaries in regional languages, with MP contact tools to enable direct civic engagement."
   url: "https://app.citizenview.in"
   tags: ["parliament", "india", "civic-tech", "multilingual", "open-data"]
+
+- name: "Judiciary Entity Map (JEM)"
+  category: "Visualisations"
+  description: "Open structural map of India's judicial ecosystem, covering courts, tribunals, and regulators. Charts appointment chains, funding flows, case backlog, and independence risk across 1,100+ institutions."
+  url: "https://github.com/dso6060/jem"
+  tags: ["india", "judiciary", "data-visualisation", "open-data", "governance"]

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -125,7 +125,7 @@
   url: "https://takshashilainst.github.io/scholar-web/"
   tags: ["policy-analysis", "research-tools", "india", "ai", "open-source"]
 
-  - name: "CitizenView"
+- name: "CitizenView"
   category: "Analytical Tools"
   description: "Makes Indian parliamentary bills accessible to citizens through plain-language summaries in regional languages, with MP contact tools to enable direct civic engagement."
   url: "https://app.citizenview.in"

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -134,5 +134,5 @@
 - name: "Judiciary Entity Map (JEM)"
   category: "Visualisations"
   description: "Open structural map of India's judicial ecosystem, covering courts, tribunals, and regulators. Charts appointment chains, funding flows, case backlog, and independence risk across 1,100+ institutions."
-  url: "https://github.com/dso6060/jem"
+  url: "https://friedso.com/apps/jem"
   tags: ["india", "judiciary", "data-visualisation", "open-data", "governance"]


### PR DESCRIPTION
Hi! This PR adds an entry for Judiciary Entity Map (JEM), which is a FOSS civic infrastructure project for legal researchers, lawyers, journalists, and policymakers (and so on) that aims to provide a map of India's judicial ecosystem via a bunch of indicators, coupled with a YAML-based data ingestion pipeline.

The source code is hosted at https://github.com/dso6060/jem (we plan to move this to a dedicated organisation later), and the dashboard can be accessed at https://friedso.com/apps/jem.

This project was initiated by @dso6060 (Divya Sornaraja) and @Prajna1999 (Prajna Prayas), and I (Agriya Khetarpal) have recently joined its development as well – all three of us were students in the 43rd cohort of the GCPP as part of the Technology and Policy specialisation at @TakshashilaInst from January to May 2026. We plan to scale this project by adding more features and improving our dataset curation, and will soon seek feedback from a wider diaspora across the legal ecosystem in India. We've even submitted a talk proposal about our project to the IndiaFOSS 2026 conference, for a start! https://fossunited.org/c/indiafoss/2026/cfp/ajdpfpbh5a

I also fixed a stray space for CitizenView just above our addition.

Thank you for your time! :)